### PR TITLE
Fix: Ensure Solr uses bundled Java 17

### DIFF
--- a/scripts/c.installer.nsi
+++ b/scripts/c.installer.nsi
@@ -11,7 +11,6 @@ RequestExecutionLevel admin
 
 ; MUI 1.67 compatible ------
 !include "MUI.nsh"
-!include "WinMessages.nsh"      ; ${WM_SETTINGCHANGE} / ${HWND_BROADCAST} — применить переменные окружения без перезагрузки
 
 ; MUI Settings
 !define MUI_ABORTWARNING
@@ -105,16 +104,16 @@ Section -Post
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "UninstallString" "$INSTDIR\uninst.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayIcon" "$INSTDIR\Nikita.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayVersion" "${PRODUCT_VERSION}"
-
-  ; Системная переменная SOLR_JAVA_HOME -> bundled Java 17.
-  ; Пишется ДО установки/старта службы, чтобы Solr поднимал нужную Java при любом
-  ; способе запуска (служба LocalSystem, консоль, ручной solr.cmd / java -jar).
-  WriteRegExpandStr HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "SOLR_JAVA_HOME" "$INSTDIR\java"
-  SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
-
   ExecWait '"$SYSDIR\cmd.exe" /c "$INSTDIR\add.firewall.rule.cmd"'
   ExecWait '"$INSTDIR\pcnsl.exe"'
   ExecWait '"$INSTDIR\Nikita.exe" --startup auto install'
+
+  ; SOLR_JAVA_HOME задаётся ТОЛЬКО в окружении службы Nikita (per-service),
+  ; а не в общесистемной переменной — чтобы не затирать чужую машинную SOLR_JAVA_HOME.
+  ; Ключ Environment (REG_MULTI_SZ) службы читается SCM при старте; пишется ПОСЛЕ
+  ; --startup auto install (он создаёт ветку службы). При sc delete (uninstall)
+  ; значение исчезает вместе с веткой службы — отдельная очистка не нужна.
+  ExecWait '"$SYSDIR\reg.exe" add "HKLM\SYSTEM\CurrentControlSet\Services\Nikita" /v Environment /t REG_MULTI_SZ /d "SOLR_JAVA_HOME=$INSTDIR\java" /f'
 SectionEnd
 
 Function un.onUninstSuccess
@@ -132,13 +131,9 @@ Section Uninstall
   SetShellVarContext all
 
   ExecWait '"$SYSDIR\sc.exe" stop Nikita'
+  ; sc delete удаляет ветку службы вместе с её Environment (SOLR_JAVA_HOME) — отдельная очистка не нужна
   ExecWait '"$SYSDIR\sc.exe" delete Nikita'
   ExecWait '"$SYSDIR\netsh.exe" advfirewall firewall delete rule name="Nikita"'
-
-  ; Убираем системную переменную SOLR_JAVA_HOME
-  DeleteRegValue HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "SOLR_JAVA_HOME"
-  SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
-
   RMDir /r $INSTDIR
   Delete "$SMPROGRAMS\Nikita\*.*"
 

--- a/scripts/c.installer.nsi
+++ b/scripts/c.installer.nsi
@@ -11,6 +11,7 @@ RequestExecutionLevel admin
 
 ; MUI 1.67 compatible ------
 !include "MUI.nsh"
+!include "WinMessages.nsh"      ; ${WM_SETTINGCHANGE} / ${HWND_BROADCAST} — применить переменные окружения без перезагрузки
 
 ; MUI Settings
 !define MUI_ABORTWARNING
@@ -104,6 +105,13 @@ Section -Post
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "UninstallString" "$INSTDIR\uninst.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayIcon" "$INSTDIR\Nikita.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayVersion" "${PRODUCT_VERSION}"
+
+  ; Системная переменная SOLR_JAVA_HOME -> bundled Java 17.
+  ; Пишется ДО установки/старта службы, чтобы Solr поднимал нужную Java при любом
+  ; способе запуска (служба LocalSystem, консоль, ручной solr.cmd / java -jar).
+  WriteRegExpandStr HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "SOLR_JAVA_HOME" "$INSTDIR\java"
+  SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
   ExecWait '"$SYSDIR\cmd.exe" /c "$INSTDIR\add.firewall.rule.cmd"'
   ExecWait '"$INSTDIR\pcnsl.exe"'
   ExecWait '"$INSTDIR\Nikita.exe" --startup auto install'
@@ -126,6 +134,11 @@ Section Uninstall
   ExecWait '"$SYSDIR\sc.exe" stop Nikita'
   ExecWait '"$SYSDIR\sc.exe" delete Nikita'
   ExecWait '"$SYSDIR\netsh.exe" advfirewall firewall delete rule name="Nikita"'
+
+  ; Убираем системную переменную SOLR_JAVA_HOME
+  DeleteRegValue HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "SOLR_JAVA_HOME"
+  SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
   RMDir /r $INSTDIR
   Delete "$SMPROGRAMS\Nikita\*.*"
 

--- a/scripts/c.installer.nsi
+++ b/scripts/c.installer.nsi
@@ -131,7 +131,10 @@ Section Uninstall
   SetShellVarContext all
 
   ExecWait '"$SYSDIR\sc.exe" stop Nikita'
-  ; sc delete удаляет ветку службы вместе с её Environment (SOLR_JAVA_HOME) — отдельная очистка не нужна
+  ; Явно убираем per-service SOLR_JAVA_HOME ДО sc delete: если удаление службы отложится
+  ; (marked-for-delete при открытых хэндлах), ключ службы может остаться до перезагрузки —
+  ; чистим Environment заранее, чтобы не оставить висящее значение. sc delete затем снесёт ключ.
+  ExecWait '"$SYSDIR\reg.exe" delete "HKLM\SYSTEM\CurrentControlSet\Services\Nikita" /v Environment /f'
   ExecWait '"$SYSDIR\sc.exe" delete Nikita'
   ExecWait '"$SYSDIR\netsh.exe" advfirewall firewall delete rule name="Nikita"'
   RMDir /r $INSTDIR


### PR DESCRIPTION
Ensure Solr uses the bundled Java 17 by setting `SOLR_JAVA_HOME` for the **Nikita Windows service only** (per-service environment) — not as a machine-wide variable.

**What the installer does**
- After the service is registered (`--startup auto install`), it writes `SOLR_JAVA_HOME=$INSTDIR\java` into the service's own environment block: `HKLM\SYSTEM\CurrentControlSet\Services\Nikita\Environment` (`REG_MULTI_SZ`). The SCM applies it when the service starts.
- On uninstall, the `Environment` value is removed explicitly (before `sc delete`, so nothing lingers if service deletion is deferred), then the service key is deleted.

**Why per-service (changed from the original machine-wide approach)**
- A pre-existing machine-level `SOLR_JAVA_HOME` (owned by another Solr/Java install) is never read, overwritten, or deleted — no backup/restore needed, no clobbering. (Addresses review feedback from Copilot and CodeRabbit.)
- No `WM_SETTINGCHANGE` broadcast is needed: the SCM reads the per-service environment at service start.

**Scope note**
This scopes the Java selection to the Nikita service. The service already resolves the bundled JDK via `resolve_java_home()`, so this just makes it explicit and deterministic. Launches outside the service (e.g. running `solr.cmd` by hand) are out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows installer now applies Java environment settings immediately for the Nikita service.
* **Bug Fixes**
  * Uninstallation now reliably removes the service-scoped Java environment setting (even when service deletion is deferred), preventing leftover configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->