### PR TITLE
Solr: keep enabled default Windows-aware in detect()

### DIFF
--- a/Nikita.py
+++ b/Nikita.py
@@ -225,7 +225,7 @@ class conf:
         g.conf.redis.db                                 =   os.getenv("REDIS_DB", "0")
         g.conf.redis.dir                                =   os.getenv("REDIS_DIR", os.path.join(g.execution.self_dir, "redis_data"))
 
-        # Solr default settings (как в globals.py: на Windows включён по умолчанию)
+        # Solr default settings (как в src/globals.py: на Windows включён по умолчанию)
         g.conf.solr.enabled                             =   t.strtobool(os.getenv("SOLR_ENABLED", "True" if is_windows else "False"))
 
         t.debug_print("Conf detection")

--- a/Nikita.py
+++ b/Nikita.py
@@ -225,8 +225,8 @@ class conf:
         g.conf.redis.db                                 =   os.getenv("REDIS_DB", "0")
         g.conf.redis.dir                                =   os.getenv("REDIS_DIR", os.path.join(g.execution.self_dir, "redis_data"))
 
-        # Solr default settings
-        g.conf.solr.enabled                             =   t.strtobool(os.getenv("SOLR_ENABLED", "False"))
+        # Solr default settings (как в globals.py: на Windows включён по умолчанию)
+        g.conf.solr.enabled                             =   t.strtobool(os.getenv("SOLR_ENABLED", "True" if is_windows else "False"))
 
         t.debug_print("Conf detection")
         d_found                                             =   False


### PR DESCRIPTION
## What

`detect()` (the 0-bases fallback in `start_all`) re-read `SOLR_ENABLED` with a hardcoded `"False"` default, overwriting the Windows-default `"True"` from `globals.py:144`.

## Why

When no 1C bases are found, the service falls into `conf.detect(initial=True)`, which ran:
```python
g.conf.solr.enabled = t.strtobool(os.getenv("SOLR_ENABLED", "False"))
```
With `SOLR_ENABLED` not set in the service environment, this flipped `enabled` True→False, so the **Solr thread was never started** — even though `print_config` logged `SOLR_ENABLED: True` (that line reads the import-time default *before* `detect()` runs). Symptom: zero Solr lines in the debug log on a service start that found 0 bases.

## Fix

Use the same `is_windows`-aware default as `globals.py`:
```python
g.conf.solr.enabled = t.strtobool(os.getenv("SOLR_ENABLED", "True" if is_windows else "False"))
```

## Testing

- `python -m py_compile Nikita.py` — OK.
- Diff vs `master` is a single line (plus comment).

> Note: the broader "`.env` not loaded in a frozen build" issue (config values all defaulting) is **not** addressed here — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Solr configuration to be platform-dependent, enabling it by default on Windows systems and disabling it on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->