### PR TITLE
[codex] Fix Windows distribution build script

### DIFF
--- a/Nikita.spec
+++ b/Nikita.spec
@@ -1,12 +1,17 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from pathlib import Path
+
+
+project_root = Path(SPECPATH)
+
 
 a = Analysis(
-    ['C:\\Users\\Administrator\\Documents\\Nikita\\Nikita.py'],
-    pathex=[],
+    [str(project_root / 'Nikita.py')],
+    pathex=[str(project_root)],
     binaries=[],
-    datas=[('LICENSE', '.')],
-    hiddenimports=['subprocess', 'cherrypy', 'urllib', 'threading', 'requests', 're', 'time', 'operator', 'json', 'psutil', 'shlex', 'platform', 'socket', 'sqlite3', 'src.parser', 'src.reader', 'src.dictionaries', 'src.messenger', 'src.globals', 'src.tools', 'src.solr', 'src.sender', 'src.redis_manager', 'src.state_manager', 'src.parser_state', 'src.cherry', 'clickhouse_driver', 'win32timezone', 'clickhouse_driver', 'win32timezone'],
+    datas=[(str(project_root / 'LICENSE'), '.')],
+    hiddenimports=['subprocess', 'cherrypy', 'urllib', 'threading', 'requests', 're', 'time', 'operator', 'json', 'psutil', 'shlex', 'platform', 'socket', 'sqlite3', 'src.parser', 'src.reader', 'src.dictionaries', 'src.messenger', 'src.globals', 'src.tools', 'src.solr', 'src.sender', 'src.redis_manager', 'src.state_manager', 'src.parser_state', 'src.cherry', 'clickhouse_driver', 'win32timezone'],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/scripts/!c.build.win.distr.cmd
+++ b/scripts/!c.build.win.distr.cmd
@@ -7,9 +7,11 @@ echo Nikita Windows Distribution Builder
 echo ==================================================
 
 echo Stopping and removing existing service...
-if exist ".\dist\Nikita\Nikita.exe" (
-    .\dist\Nikita\Nikita.exe stop 2>nul
-    .\dist\Nikita\Nikita.exe remove 2>nul
+%SystemRoot%\System32\sc.exe query Nikita >nul 2>nul
+if %errorlevel% equ 0 (
+    %SystemRoot%\System32\sc.exe stop Nikita >nul 2>nul
+    timeout /t 2 /nobreak >nul
+    %SystemRoot%\System32\sc.exe delete Nikita >nul 2>nul
 )
 
 echo.

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,4 +1,4 @@
-# build.ps1 - Основная сборка Nikita
+﻿# build.ps1 - Основная сборка Nikita
 # Использование: .\build.ps1 [-Optimize] [-NoTest]
 
 param(

--- a/scripts/common.ps1
+++ b/scripts/common.ps1
@@ -1,4 +1,4 @@
-# common.ps1 - Общие функции для сборки Nikita
+﻿# common.ps1 - Общие функции для сборки Nikita
 # Использование: Import-Module $PSScriptRoot\common.ps1
 
 $Script:JavaVersion                                 =   "17"
@@ -390,6 +390,9 @@ function Invoke-PyInstaller {
 
     Write-Info "Запуск PyInstaller..."
 
+    $specPath = Join-Path $ProjectRoot "Nikita.spec"
+    $useSpecBuild = $Optimize -and $OutputName -eq "Nikita" -and (Test-Path $specPath)
+
     # Базовые аргументы
     $pyinstallerArgs = @(
         "$ProjectRoot\Nikita.py",
@@ -448,6 +451,7 @@ function Invoke-PyInstaller {
     try {
         # Определяем путь к pyinstaller
         $pyinstallerPath                                    =   $null
+        $runViaPythonModule                                 =   $false
         if (Get-Command pyinstaller -ErrorAction SilentlyContinue) {
             $pyinstallerPath                                =   "pyinstaller"
         } elseif ($Script:PythonPath) {
@@ -461,10 +465,21 @@ function Invoke-PyInstaller {
             } else {
                 # Пробуем запустить через python -m PyInstaller
                 $pyinstallerPath                            =   $Script:PythonPath
-                $pyinstallerArgs                            =   @("-m", "PyInstaller") + $pyinstallerArgs
+                $runViaPythonModule                         =   $true
+                if (!$useSpecBuild) {
+                    $pyinstallerArgs                        =   @("-m", "PyInstaller") + $pyinstallerArgs
+                }
             }
         } else {
             throw "PyInstaller не найден и путь к Python неизвестен"
+        }
+
+        if ($useSpecBuild) {
+            Write-Info "Используется переносимый spec: $specPath"
+            $pyinstallerArgs = @("--clean", "--noconfirm", "--log-level", "DEBUG", $specPath)
+            if ($runViaPythonModule) {
+                $pyinstallerArgs = @("-m", "PyInstaller") + $pyinstallerArgs
+            }
         }
 
         Write-Info "Команда: $pyinstallerPath $($pyinstallerArgs -join ' ')"
@@ -505,7 +520,23 @@ function Get-JavaMajorVersion {
     )
 
     try {
-        $versionOutput = & $JavaExe -version 2>&1 | Out-String
+        if (!(Test-Path $JavaExe)) {
+            return -1
+        }
+
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $startInfo.FileName = $JavaExe
+        $startInfo.Arguments = "-version"
+        $startInfo.UseShellExecute = $false
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+
+        $process = [System.Diagnostics.Process]::Start($startInfo)
+        $stdOut = $process.StandardOutput.ReadToEnd()
+        $stdErr = $process.StandardError.ReadToEnd()
+        $process.WaitForExit()
+
+        $versionOutput = "$stdOut`n$stdErr"
         if ($versionOutput -match 'version "([^"]+)"') {
             $version = $Matches[1]
             if ($version.StartsWith("1.")) {

--- a/scripts/create-installer.ps1
+++ b/scripts/create-installer.ps1
@@ -1,4 +1,4 @@
-# create-installer.ps1 - Создание Windows инсталлятора с автоматической загрузкой NSIS
+﻿# create-installer.ps1 - Создание Windows инсталлятора с автоматической загрузкой NSIS
 # Использование: .\create-installer.ps1
 
 $ErrorActionPreference                              =   "Stop"

--- a/scripts/download-deps.ps1
+++ b/scripts/download-deps.ps1
@@ -1,4 +1,4 @@
-# download-deps.ps1 - Загрузка зависимостей Java и Solr
+﻿# download-deps.ps1 - Загрузка зависимостей Java и Solr
 # Использование: .\download-deps.ps1 [-Force]
 
 param(

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -1,4 +1,4 @@
-# run-tests.ps1 - Запуск тестов Nikita для Windows
+﻿# run-tests.ps1 - Запуск тестов Nikita для Windows
 # Использование: .\run-tests.ps1 [-Verbose] [-CreateVenv]
 
 param(

--- a/src/tools.py
+++ b/src/tools.py
@@ -105,6 +105,8 @@ class tools():
                     g.debug.filehandle.write(dp_msg + "\n")
                     g.debug.filehandle.flush()
                 else:                                                                                                   # если ещё не открыт
+                    if not g.debug.dir or not g.debug.filename:
+                        return
                     if(not os.path.exists(g.debug.dir)):
                         os.makedirs(g.debug.dir)
                     g.debug.filehandle                      =   open(g.debug.filename, 'a', encoding='UTF8')


### PR DESCRIPTION
## What changed

- Make `Nikita.spec` portable by resolving paths from `SPECPATH` instead of a hard-coded local checkout path.
- Use the portable spec for optimized Windows builds so PyInstaller does not regenerate it with absolute paths.
- Add UTF-8 BOM to PowerShell scripts so Windows PowerShell parses Russian strings correctly.
- Fix Java version detection by reading `java -version` stderr without tripping PowerShell error handling.
- Avoid launching `Nikita.exe` to stop/remove the service during distribution builds; use `sc.exe` directly.
- Guard debug logging when debug paths are not initialized yet.

## Why

The Windows distribution script could fail before or during build because PowerShell misread UTF-8 scripts, Java 17 detection returned a false negative, and service cleanup invoked the bundled executable early enough to hit uninitialized debug paths.

## Validation

- `git diff --check`
- Parsed all PowerShell build scripts with `System.Management.Automation.Language.Parser`.
- `python -` smoke test for `tools.debug_print()` with empty debug paths.
- `powershell -NoProfile -ExecutionPolicy Bypass -File "scripts\build.ps1" -Optimize -NoTest`
- `dist\Nikita\Nikita.exe stop` no longer emits the StateManager/debug path traceback; without admin rights it only reports Windows access denied.